### PR TITLE
Support for Ruby 2.0

### DIFF
--- a/lib/sem.rb
+++ b/lib/sem.rb
@@ -10,46 +10,51 @@ module Sem
   require "sem/api"
   require "sem/views"
 
-  # Returns exit status as a number.
-  def self.start(args)
-    Sem::CLI.start(args)
+  class << self
 
-    0
-  rescue Sem::Errors::Auth::NoCredentials
-    on_no_credentials
+    # Returns exit status as a number.
+    def start(args)
+      Sem::CLI.start(args)
 
-    1
-  rescue Sem::Errors::Auth::InvalidCredentials
-    on_invalid_credentials
+      0
+    rescue Sem::Errors::Auth::NoCredentials
+      on_no_credentials
 
-    1
-  rescue StandardError => e
-    on_unhandled_error(e)
+      1
+    rescue Sem::Errors::Auth::InvalidCredentials
+      on_invalid_credentials
 
-    1
-  end
+      1
+    rescue StandardError => e
+      on_unhandled_error(e)
 
-  private_class_method def self.on_no_credentials
-    puts "[ERROR] You are not logged in."
-    puts ""
-    puts "Log in with '#{Sem::CLI.program_name} login --auth-token <token>'"
-  end
+      1
+    end
 
-  private_class_method def self.on_invalid_credentials
-    puts "[ERROR] Your credentials are invalid."
-    puts ""
-    puts "Log in with '#{Sem::CLI.program_name} login --auth-token <token>'"
-  end
+    private
 
-  private_class_method def self.on_unhandled_error(exception)
-    puts "[PANIC] Unhandled error."
-    puts ""
-    puts "Well, this is emberassing. An unknown error was detected."
-    puts ""
-    puts "Backtrace: "
-    puts exception.backtrace
-    puts ""
-    puts "Please report this issue to https://semaphoreci.com/support."
+    def on_no_credentials
+      puts "[ERROR] You are not logged in."
+      puts ""
+      puts "Log in with '#{Sem::CLI.program_name} login --auth-token <token>'"
+    end
+
+    def on_invalid_credentials
+      puts "[ERROR] Your credentials are invalid."
+      puts ""
+      puts "Log in with '#{Sem::CLI.program_name} login --auth-token <token>'"
+    end
+
+    def on_unhandled_error(exception)
+      puts "[PANIC] Unhandled error."
+      puts ""
+      puts "Well, this is emberassing. An unknown error was detected."
+      puts ""
+      puts "Backtrace: "
+      puts exception.backtrace
+      puts ""
+      puts "Please report this issue to https://semaphoreci.com/support."
+    end
   end
 
 end

--- a/lib/sem/api/users_with_permissions.rb
+++ b/lib/sem/api/users_with_permissions.rb
@@ -49,7 +49,7 @@ module Sem
         end
 
         def to_hash(array)
-          Hash[array.each_slice(2).to_a]
+          Hash[array]
         end
       end
     end

--- a/lib/sem/api/users_with_permissions.rb
+++ b/lib/sem/api/users_with_permissions.rb
@@ -27,7 +27,7 @@ module Sem
         def teams_by_permission(all_teams)
           groups = all_teams.group_by(&:permission)
 
-          groups.sort_by { |permission, _| LEVELS[permission] }.to_h.values
+          to_hash(groups.sort_by { |permission, _| LEVELS[permission] }).values
         end
 
         def users_for_team_groups(groups)
@@ -41,11 +41,15 @@ module Sem
         def users_for_team(team)
           users = client.users.list_for_team(team.id)
 
-          users.map { |user| [user.username, transform_user(user, team)] }.to_h
+          to_hash(users.map { |user| [user.username, transform_user(user, team)] })
         end
 
         def transform_user(user, team)
           Users.to_hash(user).merge(:permission => team.permission)
+        end
+
+        def to_hash(array)
+          Hash[array.each_slice(2).to_a]
         end
       end
     end

--- a/sem.gemspec
+++ b/sem.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.47.1"
-  spec.add_development_dependency "rubocop-rspec", "~> 1.13.0"
+  spec.add_development_dependency "rubocop-rspec", "1.5.0"
   spec.add_development_dependency "simplecov", "~> 0.13"
   spec.add_development_dependency "byebug"
 end

--- a/sem.gemspec
+++ b/sem.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "semaphore_client", "~> 2.0.5"
-  spec.add_dependency "dracula", "~> 0.1.0"
+  spec.add_dependency "dracula", "~> 0.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
- Updated dracula to Ruby 2.0 supporting version
- Removed instances of private class method
- Rubocop-Rspec 1.5.1 was the last version that supported 2.0