### PR TITLE
Trace mode

### DIFF
--- a/lib/sem.rb
+++ b/lib/sem.rb
@@ -12,10 +12,24 @@ module Sem
   require "sem/api"
   require "sem/views"
 
+  LOG_LEVEL_TRACE = :trace
+  LOG_LEVEL_ERROR = :error
+
   class << self
+    attr_writer :log_level
+
+    def log_level
+      @log_level || LOG_LEVEL_ERROR
+    end
 
     # Returns exit status as a number.
     def start(args)
+      if args.include?("--trace")
+        @log_level = LOG_LEVEL_TRACE
+
+        args.delete("--trace")
+      end
+
       Sem::CLI.start(args)
 
       0

--- a/lib/sem/api/base.rb
+++ b/lib/sem/api/base.rb
@@ -3,9 +3,9 @@ module Sem
     class Base
       class << self
         def client
-          @client ||= SemaphoreClient.new(
-            Sem::Configuration.auth_token,
-            Sem::Configuration.api_url
+          @client ||= SemaphoreClient.new(Sem::Configuration.auth_token,
+            :api_url => Sem::Configuration.api_url,
+            :verbose => true
           )
         end
 

--- a/lib/sem/api/base.rb
+++ b/lib/sem/api/base.rb
@@ -4,9 +4,9 @@ module Sem
       class << self
         def client
           @client ||= SemaphoreClient.new(Sem::Configuration.auth_token,
-            :api_url => Sem::Configuration.api_url,
-            :verbose => true
-          )
+                                          :api_url => Sem::Configuration.api_url,
+                                          :verbose => (Sem.log_level == Sem::LOG_LEVEL_TRACE)
+                                         )
         end
 
         def raise_not_found(resource, path)

--- a/sem.gemspec
+++ b/sem.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "semaphore_client", "2.0.9"
+  spec.add_dependency "semaphore_client", "2.1.1"
   spec.add_dependency "dracula", "~> 0.2.2"
   spec.add_dependency "pmap", "~> 1.1.1"
 

--- a/spec/lib/sem/api/base_spec.rb
+++ b/spec/lib/sem/api/base_spec.rb
@@ -9,9 +9,11 @@ describe Sem::API::Base do
     let(:client) { instance_double(SemaphoreClient) }
 
     before do
+      options = { :api_url => api_url, :verbose => (Sem.log_level == Sem::LOG_LEVEL_TRACE) }
+
       allow(Sem::Configuration).to receive(:auth_token).and_return(auth_token)
       allow(Sem::Configuration).to receive(:api_url).and_return(api_url)
-      allow(SemaphoreClient).to receive(:new).with(auth_token, api_url).and_return(client)
+      allow(SemaphoreClient).to receive(:new).with(auth_token, options).and_return(client)
     end
 
     it "returns the client" do

--- a/spec/sem_spec.rb
+++ b/spec/sem_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe Sem do
   end
 
   describe ".start" do
+    describe "--trace argument" do
+      it "sets the output to trace level" do
+        expect { Sem.start(["--trace"]) }
+          .to change { Sem.log_level }
+          .from(Sem::LOG_LEVEL_ERROR)
+          .to(Sem::LOG_LEVEL_TRACE)
+      end
+    end
+
     it "passed the arguments to the CLI client" do
       expect(Sem::CLI).to receive(:start).with(["a", "b", "c"])
 


### PR DESCRIPTION
From now on, you can pass a special flag `--trace` to the CLI in order
to trace every API call.

``` bash
sem shared-configs:list --trace
```

https://github.com/renderedtext/cli/issues/58