### PR TITLE
Fix rename action

### DIFF
--- a/lib/sem/api/shared_config.rb
+++ b/lib/sem/api/shared_config.rb
@@ -85,14 +85,6 @@ class Sem::API::SharedConfig < SimpleDelegator
   end
 
   def update!(args)
-    if args[:name]
-      new_org_name, new_name = Sem::SRN.parse_shared_config(args[:name])
-
-      abort "Shared Configuration can't change its organization" unless new_org_name == org_name
-
-      args[:name] = new_name
-    end
-
     shared_config = Sem::API::Base.client.shared_configs.update(id, args)
 
     if shared_config.nil?

--- a/lib/sem/api/shared_config.rb
+++ b/lib/sem/api/shared_config.rb
@@ -85,6 +85,14 @@ class Sem::API::SharedConfig < SimpleDelegator
   end
 
   def update!(args)
+    if args[:name]
+      new_org_name, new_name = Sem::SRN.parse_shared_config(args[:name])
+
+      abort "Shared Configuration can't change its organization" unless new_org_name == org_name
+
+      args[:name] = new_name
+    end
+
     shared_config = Sem::API::Base.client.shared_configs.update(id, args)
 
     if shared_config.nil?

--- a/lib/sem/api/team.rb
+++ b/lib/sem/api/team.rb
@@ -40,14 +40,6 @@ class Sem::API::Team < SimpleDelegator
   end
 
   def update(args)
-    if args[:name]
-      new_org_name, new_name = Sem::SRN.parse_team(args[:name])
-
-      abort "Team can't change its organization" unless new_org_name == org_name
-
-      args[:name] = new_name
-    end
-
     new_team = Sem::API::Base.client.teams.update(id, args)
 
     raise Sem::Errors::ResourceNotUpdated.new("Team", [@org_name, name]) unless new_team

--- a/lib/sem/api/team.rb
+++ b/lib/sem/api/team.rb
@@ -40,9 +40,17 @@ class Sem::API::Team < SimpleDelegator
   end
 
   def update(args)
+    if args[:name]
+      new_org_name, new_name = Sem::SRN.parse_team(args[:name])
+
+      abort "Team can't change its organization" unless new_org_name == org_name
+
+      args[:name] = new_name
+    end
+
     new_team = Sem::API::Base.client.teams.update(id, args)
 
-    raise Sem::Errors::ResourceNotUpdated.new("Team", [@org_name, name]) if new_team.nil?
+    raise Sem::Errors::ResourceNotUpdated.new("Team", [@org_name, name]) unless new_team
 
     self.class.new(@org_name, new_team)
   end

--- a/lib/sem/cli/shared_configs.rb
+++ b/lib/sem/cli/shared_configs.rb
@@ -27,8 +27,13 @@ class Sem::CLI::SharedConfigs < Dracula
 
   desc "rename", "rename a shared configuration"
   def rename(old_shared_config_name, new_shared_config_name)
+    old_org_name, _old_name = Sem::SRN.parse_shared_config(old_shared_config_name)
+    new_org_name, new_name = Sem::SRN.parse_shared_config(new_shared_config_name)
+
+    abort "Shared Configuration can't change its organization" unless new_org_name == old_org_name
+
     shared_config = Sem::API::SharedConfig.find!(old_shared_config_name)
-    shared_config = shared_config.update!(:name => new_shared_config_name)
+    shared_config = shared_config.update!(:name => new_name)
 
     Sem::Views::SharedConfigs.info(shared_config)
   end

--- a/lib/sem/cli/teams.rb
+++ b/lib/sem/cli/teams.rb
@@ -30,8 +30,13 @@ class Sem::CLI::Teams < Dracula
 
   desc "rename", "change the name of the team"
   def rename(old_team_name, new_team_name)
+    old_org_name, _old_name = Sem::SRN.parse_team(old_team_name)
+    new_org_name, new_name = Sem::SRN.parse_team(new_team_name)
+
+    abort "Team can't change its organization" unless new_org_name == old_org_name
+
     team = Sem::API::Team.find!(old_team_name)
-    team = team.update(:name => new_team_name)
+    team = team.update(:name => new_name)
 
     Sem::Views::Teams.info(team)
   end

--- a/lib/sem/version.rb
+++ b/lib/sem/version.rb
@@ -1,3 +1,3 @@
 module Sem
-  VERSION = "0.2.4".freeze
+  VERSION = "0.2.5".freeze
 end

--- a/spec/lib/sem/cli/shared_configs_spec.rb
+++ b/spec/lib/sem/cli/shared_configs_spec.rb
@@ -119,7 +119,7 @@ describe Sem::CLI::SharedConfigs do
 
     context "update succeds" do
       before do
-        stub_api(:patch, "/shared_configs/#{shared_config[:id]}").to_return(200, shared_config)
+        stub_api(:patch, "/shared_configs/#{shared_config[:id]}", :name => "secrets").to_return(200, shared_config)
 
         stub_api(:get, "/shared_configs/#{shared_config[:id]}/config_files").to_return(200, [])
         stub_api(:get, "/shared_configs/#{shared_config[:id]}/env_vars").to_return(200, [])

--- a/spec/lib/sem/cli/teams_spec.rb
+++ b/spec/lib/sem/cli/teams_spec.rb
@@ -116,7 +116,7 @@ describe Sem::CLI::Teams do
         stub_api(:get, "/orgs/rt/teams").to_return(200, [team])
         stub_api(:get, "/teams/#{team[:id]}/users").to_return(200, [user])
 
-        stub_api(:patch, "/teams/#{team[:id]}").to_return(200, team)
+        stub_api(:patch, "/teams/#{team[:id]}", :name => "admins").to_return(200, team)
       end
 
       it "displays the team" do

--- a/spec/support/web_stubs.rb
+++ b/spec/support/web_stubs.rb
@@ -1,19 +1,23 @@
 module WebStubs
 
-  def stub_api(method, path)
-    ApiRequest.new(method, path)
+  def stub_api(method, path, request_body = nil)
+    ApiRequest.new(method, path, request_body)
   end
 
   class ApiRequest
-    def initialize(method, path)
+    def initialize(method, path, request_body)
       @method = method
       @path = path
+      @request_body = request_body
     end
 
     def to_return(code, body)
       url = "https://api.semaphoreci.com/v2#{@path}"
 
-      WebMock.stub_request(@method, url).to_return(:status => code, :body => body.to_json)
+      stub = WebMock.stub_request(@method, url)
+      stub = stub.with(:body => @request_body.to_json) if @request_body
+
+      stub.to_return(:status => code, :body => body.to_json)
     end
   end
 


### PR DESCRIPTION
In this PR:

#### Webmock based tests can now match on request body:

For example, now we can test if the body sent to the server is `:name => "secrets`.

``` ruby
stub_api(:patch, "/shared_configs/#{shared_config[:id]}", :name => "secrets").to_return(200, shared_config)
```

#### Fix in team rename and shared config rename

We sent the full SRN name in the rename request. This was a bug.