### PR TITLE
Dash flags

### DIFF
--- a/lib/sem/cli.rb
+++ b/lib/sem/cli.rb
@@ -13,12 +13,12 @@ module Sem
     end
 
     desc "login", "Log in to semaphore from the command line"
-    option :auth_token, :required => true
+    option "auth-token", :required => true
     long_desc <<-DESC
 You can find your auth_token on the bottom of the users settings page https://semaphoreci.com/users/edit.
 DESC
     def login
-      auth_token = options[:auth_token]
+      auth_token = options["auth-token"]
 
       if Sem::Configuration.valid_auth_token?(auth_token)
         Sem::Configuration.export_auth_token(auth_token)

--- a/spec/lib/sem/cli_spec.rb
+++ b/spec/lib/sem/cli_spec.rb
@@ -21,11 +21,11 @@ describe Sem::CLI do
       it "sets the auth token" do
         expect(Sem::Configuration).to receive(:export_auth_token).with("123456")
 
-        sem_run("login --auth_token 123456")
+        sem_run("login --auth-token 123456")
       end
 
       it "displays a success message" do
-        stdout, stderr, status = sem_run("login --auth_token 123456")
+        stdout, stderr, status = sem_run("login --auth-token 123456")
 
         msg = [
           "Your credentials have been saved to #{Sem::Configuration::CREDENTIALS_PATH}."
@@ -41,7 +41,7 @@ describe Sem::CLI do
       before { allow(Sem::Configuration).to receive(:valid_auth_token?).and_return(false) }
 
       it "writes an error to the output" do
-        _stdout, stderr, status = sem_run("login --auth_token 123456")
+        _stdout, stderr, status = sem_run("login --auth-token 123456")
 
         msg = [
           "[ERROR] Token is invalid!"
@@ -54,7 +54,7 @@ describe Sem::CLI do
       it "does not set the auth token" do
         expect(Sem::Configuration).to_not receive(:export_auth_token).with("123456")
 
-        sem_run("login --auth_token 123456")
+        sem_run("login --auth-token 123456")
       end
     end
   end


### PR DESCRIPTION
It is easier and nicer to type `sem login --auth-token <token>` instead
of `sem login --auth_token <token>`.