### PR TITLE
Tracing for non-200 responses

### DIFF
--- a/lib/sem.rb
+++ b/lib/sem.rb
@@ -13,20 +13,17 @@ module Sem
   require "sem/api"
   require "sem/views"
 
-  LOG_LEVEL_TRACE = :trace
-  LOG_LEVEL_ERROR = :error
-
   class << self
     attr_writer :log_level
 
-    def log_level
-      @log_level || LOG_LEVEL_ERROR
+    def trace?
+      @trace_mode == true
     end
 
     # Returns exit status as a number.
     def start(args)
       if args.include?("--trace")
-        @log_level = LOG_LEVEL_TRACE
+        @trace_mode = true
 
         args.delete("--trace")
       end

--- a/lib/sem/api/base.rb
+++ b/lib/sem/api/base.rb
@@ -2,7 +2,7 @@ module Sem::API::Base
   module_function
 
   def client
-    @client ||= create_api_client(
+    @client ||= create_new_api_client(
       Sem::Configuration.api_url,
       Sem::Configuration.auth_token)
   end

--- a/lib/sem/api/base.rb
+++ b/lib/sem/api/base.rb
@@ -2,12 +2,25 @@ module Sem::API::Base
   module_function
 
   def client
-    @client ||= SemaphoreClient.new(
-      Sem::Configuration.auth_token,
-      :api_url => Sem::Configuration.api_url,
-      :verbose => (Sem.log_level == Sem::LOG_LEVEL_TRACE),
-      :auto_paginate => true
-    )
+    @client ||= create_api_client(
+      Sem::Configuration.api_url,
+      Sem::Configuration.auth_token)
+  end
+
+  def create_new_api_client(api_url, auth_token)
+    SemaphoreClient.new(auth_token, :api_url => api_url,
+                                    :logger => api_logger,
+                                    :auto_paginate => true)
+  end
+
+  def api_logger
+    return nil unless Sem.trace?
+    return @api_logger if defined?(@api_logger)
+
+    @api_logger = Logger.new(STDOUT)
+    @api_logger.level = Logger::DEBUG
+
+    @api_logger
   end
 
 end

--- a/lib/sem/configuration.rb
+++ b/lib/sem/configuration.rb
@@ -7,13 +7,7 @@ module Sem
 
     class << self
       def valid_auth_token?(auth_token)
-        client = SemaphoreClient.new(
-          auth_token,
-          :api_url => api_url,
-          :verbose => (Sem.log_level == Sem::LOG_LEVEL_TRACE)
-        )
-
-        client.orgs.list!
+        Sem::API::Base.create_new_api_client(api_url, auth_token).orgs.list!
 
         true
       rescue SemaphoreClient::Exceptions::Base

--- a/sem.gemspec
+++ b/sem.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "semaphore_client", "2.6.0"
+  spec.add_dependency "semaphore_client", "2.7.0"
   spec.add_dependency "dracula", "~> 0.4.0"
   spec.add_dependency "pmap", "~> 1.1.1"
 

--- a/spec/lib/sem/configuration_spec.rb
+++ b/spec/lib/sem/configuration_spec.rb
@@ -3,30 +3,21 @@ require "spec_helper"
 describe Sem::Configuration do
   let(:credentials_path) { File.expand_path(Sem::Configuration::CREDENTIALS_PATH) }
   let(:api_url_path) { File.expand_path(Sem::Configuration::API_URL_PATH) }
-
-  let(:auth_token) { "auth_token" }
-  let(:api_url) { "api_url" }
+  let(:auth_token) { "vodafone" }
 
   describe ".valid_auth_token?" do
-    let(:orgs_api) { instance_double(SemaphoreClient::Api::Org, :list! => nil) }
-    let(:client) { instance_double(SemaphoreClient, :orgs => orgs_api) }
-
-    before do
-      options = { :api_url => api_url, :verbose => false }
-      allow(described_class).to receive(:api_url).and_return(api_url)
-      allow(SemaphoreClient).to receive(:new).with(auth_token, options).and_return(client)
-    end
-
     context "listing orgs fails" do
-      before { allow(orgs_api).to receive(:list!).and_raise(SemaphoreClient::Exceptions::Base) }
-
       it "return false" do
+        stub_api(:get, "/orgs").to_return(404, "")
+
         expect(Sem::Configuration.valid_auth_token?(auth_token)).to eq(false)
       end
     end
 
     context "listing orgs succeds" do
       it "return true" do
+        stub_api(:get, "/orgs").to_return(200, [])
+
         expect(Sem::Configuration.valid_auth_token?(auth_token)).to eq(true)
       end
     end
@@ -99,13 +90,13 @@ describe Sem::Configuration do
     context "api_url file exists" do
       before do
         allow(File).to receive(:file?).with(api_url_path).and_return(true)
-        allow(File).to receive(:read).with(api_url_path).and_return(api_url)
+        allow(File).to receive(:read).with(api_url_path).and_return("stg1-semaphore.semaphoreci.com")
       end
 
       it "returns the custom api url" do
         return_value = described_class.api_url
 
-        expect(return_value).to eql(api_url)
+        expect(return_value).to eql("stg1-semaphore.semaphoreci.com")
       end
     end
 

--- a/spec/sem_spec.rb
+++ b/spec/sem_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe Sem do
   describe ".start" do
     describe "--trace argument" do
       it "sets the output to trace level" do
-        expect { Sem.start(["--trace"]) }
-          .to change { Sem.log_level }
-          .from(Sem::LOG_LEVEL_ERROR)
-          .to(Sem::LOG_LEVEL_TRACE)
+        expect { Sem.start(["--trace"]) }.to change { Sem.trace? }.from(false).to(true)
       end
     end
 

--- a/spec/support/web_stubs.rb
+++ b/spec/support/web_stubs.rb
@@ -12,9 +12,7 @@ module WebStubs
     end
 
     def to_return(code, body, headers = {})
-      url = "https://api.semaphoreci.com/v2#{@path}"
-
-      stub = WebMock.stub_request(@method, url)
+      stub = WebMock.stub_request(@method, /.*semaphoreci.com\/v2#{@path}.*/)
       stub = stub.with(:body => @request_body.to_json) if @request_body
 
       stub.to_return(:status => code, :body => body.to_json, :headers => headers)

--- a/spec/support/web_stubs.rb
+++ b/spec/support/web_stubs.rb
@@ -12,7 +12,9 @@ module WebStubs
     end
 
     def to_return(code, body, headers = {})
-      stub = WebMock.stub_request(@method, /.*semaphoreci.com\/v2#{@path}.*/)
+      url = "https://api.semaphoreci.com/v2#{@path}"
+
+      stub = WebMock.stub_request(@method, url)
       stub = stub.with(:body => @request_body.to_json) if @request_body
 
       stub.to_return(:status => code, :body => body.to_json, :headers => headers)


### PR DESCRIPTION
Faraday middlewares have to be ordered in the reverse order in which we want them to execute on finish callbacks.

Updated the api client and updated the interface of the loggers.

<img width="843" alt="screen shot 2017-10-05 at 2 03 07 pm" src="https://user-images.githubusercontent.com/1779493/31227956-041c2884-a9dc-11e7-9d49-6cf5c0917c19.png">
