### PR TITLE
Stripped Heredocs

### DIFF
--- a/lib/sem.rb
+++ b/lib/sem.rb
@@ -4,6 +4,7 @@ require "semaphore_client"
 require "fileutils"
 require "pmap"
 require "delegate"
+require "sem/core_ext/string.rb"
 
 module Sem
   require "sem/helpers"

--- a/lib/sem/cli.rb
+++ b/lib/sem/cli.rb
@@ -15,13 +15,14 @@ module Sem
     desc "login", "Log in to Semaphore from the command line"
     option "auth-token", :required => true
     long_desc <<-DESC
-Examples:
+      Examples:
 
-    $ sem login --auth-token abcd12345
-    Your credentials have been saved to #{Sem::Configuration::CREDENTIALS_PATH}."
+          $ sem login --auth-token abcd12345
+          Your credentials have been saved to #{Sem::Configuration::CREDENTIALS_PATH}."
 
-You can find your auth-token on the bottom of the users settings page <https://semaphoreci.com/users/edit>.
-DESC
+      You can find your auth-token on the bottom of the users
+      settings page <https://semaphoreci.com/users/edit>.
+    DESC
     def login
       auth_token = options["auth-token"]
 
@@ -36,11 +37,11 @@ DESC
 
     desc "logout", "Log out from semaphore"
     long_desc <<-DESC
-Examples:
+      Examples:
 
-    $ sem logout
-    Logged out.
-DESC
+          $ sem logout
+          Logged out.
+    DESC
     def logout
       Sem::Configuration.delete_auth_token
 

--- a/lib/sem/cli/orgs.rb
+++ b/lib/sem/cli/orgs.rb
@@ -1,14 +1,14 @@
 class Sem::CLI::Orgs < Dracula
 
   desc "list", "List all organizations"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem orgs:list
-    ID                                    NAME
-    5bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext
-    99c7ed43-ac8a-487e-b488-c38bc757a034  z-fighters
-DESC
+      $ sem orgs:list
+      ID                                    NAME
+      5bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext
+      99c7ed43-ac8a-487e-b488-c38bc757a034  z-fighters
+  DESC
   def list
     orgs = Sem::API::Org.all
 
@@ -20,15 +20,15 @@ DESC
   end
 
   desc "info", "shows detailed information about an organization"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem orgs:info renderedtext
-    ID       5bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name     renderedtext
-    Created  2017-08-01 13:14:40 +0200
-    Updated  2017-08-02 13:14:40 +0200
-DESC
+      $ sem orgs:info renderedtext
+      ID       5bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name     renderedtext
+      Created  2017-08-01 13:14:40 +0200
+      Updated  2017-08-02 13:14:40 +0200
+  DESC
   def info(org_name)
     org = Sem::API::Org.find!(org_name)
 
@@ -36,15 +36,15 @@ DESC
   end
 
   desc "members", "list members of an organization"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem orgs:members renderedtext
-    NAME
-    darko
-    shiroyasha
-    bmarkons
-DESC
+      $ sem orgs:members renderedtext
+      NAME
+      darko
+      shiroyasha
+      bmarkons
+  DESC
   def members(org_name)
     org = Sem::API::Org.find!(org_name)
 

--- a/lib/sem/cli/projects.rb
+++ b/lib/sem/cli/projects.rb
@@ -4,11 +4,11 @@ class Sem::CLI::Projects < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem projects:list
-        NAME
-        ID                                    NAME
-        99c7ed43-ac8a-487e-b488-c38bc757a034  rt/cli
-        99c7ed43-ac8a-487e-b488-c38bc757a034  rt/api
+       $ sem projects:list
+       NAME
+       ID                                    NAME
+       99c7ed43-ac8a-487e-b488-c38bc757a034  rt/cli
+       99c7ed43-ac8a-487e-b488-c38bc757a034  rt/api
   DESC
   def list
     projects = Sem::API::Project.all
@@ -24,11 +24,11 @@ class Sem::CLI::Projects < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem projects:info renderedtext/cli
-        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name     renderedtext/cli
-        Created  2017-08-01 13:14:40 +0200
-        Updated  2017-08-02 13:14:40 +0200
+      $ sem projects:info renderedtext/cli
+      ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name     renderedtext/cli
+      Created  2017-08-01 13:14:40 +0200
+      Updated  2017-08-02 13:14:40 +0200
   DESC
   def info(project_name)
     project = Sem::API::Project.find!(project_name)
@@ -41,23 +41,23 @@ class Sem::CLI::Projects < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem projects:create renderedtext/cli --url git@github.com:renderedtext/cli.git
-        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name     renderedtext/cli
-        Created  2017-08-01 13:14:40 +0200
-        Updated  2017-08-02 13:14:40 +0200
+      $ sem projects:create renderedtext/cli --url git@github.com:renderedtext/cli.git
+      ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name     renderedtext/cli
+      Created  2017-08-01 13:14:40 +0200
+      Updated  2017-08-02 13:14:40 +0200
 
-        $ sem projects:create renderedtext/api --url https://github.com/renderedtext/api
-        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name     renderedtext/api
-        Created  2017-08-01 13:14:40 +0200
-        Updated  2017-08-02 13:14:40 +0200
+      $ sem projects:create renderedtext/api --url https://github.com/renderedtext/api
+      ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name     renderedtext/api
+      Created  2017-08-01 13:14:40 +0200
+      Updated  2017-08-02 13:14:40 +0200
 
-        $ sem projects:create renderedtext/api-tests --url https://github.com/renderedtext/api
-        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name     renderedtext/api-tests
-        Created  2017-08-01 13:14:40 +0200
-        Updated  2017-08-02 13:14:40 +0200
+      $ sem projects:create renderedtext/api-tests --url https://github.com/renderedtext/api
+      ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name     renderedtext/api-tests
+      Created  2017-08-01 13:14:40 +0200
+      Updated  2017-08-02 13:14:40 +0200
   DESC
   def create(project_name)
     url = Sem::Helpers::GitUrl.new(options[:url])
@@ -81,10 +81,10 @@ class Sem::CLI::Projects < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem projects:files:list renderedtext/cli
-          ID                                    PATH              ENCRYPTED?
-          77c7ed43-ac8a-487e-b488-c38bc757a034  /etc/a            true
-          11c7ed43-bc8a-a87e-ba88-a38ba757a034  /var/secrets.txt  true
+        $ sem projects:files:list renderedtext/cli
+        ID                                    PATH              ENCRYPTED?
+        77c7ed43-ac8a-487e-b488-c38bc757a034  /etc/a            true
+        11c7ed43-bc8a-a87e-ba88-a38ba757a034  /var/secrets.txt  true
     DESC
     def list(project_name)
       project = Sem::API::Project.find!(project_name)
@@ -100,10 +100,10 @@ class Sem::CLI::Projects < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem projects:env-vars:list renderedtext/cli
-          ID                                    NAME    ENCRYPTED?  CONTENT
-          9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  false       aaa
-          1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
+        $ sem projects:env-vars:list renderedtext/cli
+        ID                                    NAME    ENCRYPTED?  CONTENT
+        9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  false       aaa
+        1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
     DESC
     def list(project_name)
       project = Sem::API::Project.find!(project_name)
@@ -119,10 +119,10 @@ class Sem::CLI::Projects < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem projects:secrets:list renderedtext/cli
-          ID                                    NAME                 CONFIG FILES  ENV VARS
-          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
-          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/secrets            0         1
+        $ sem projects:secrets:list renderedtext/cli
+        ID                                    NAME                 CONFIG FILES  ENV VARS
+        99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
+        99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/secrets            0         1
     DESC
     def list(project_name)
       project = Sem::API::Project.find!(project_name)
@@ -139,8 +139,8 @@ class Sem::CLI::Projects < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem projects:secrets:add renderedtext/cli renderedtext/secrets
-          Secret renderedtext/secrets added to the project.
+        $ sem projects:secrets:add renderedtext/cli renderedtext/secrets
+        Secret renderedtext/secrets added to the project.
     DESC
     def add(project_name, secret_name)
       project = Sem::API::Project.find!(project_name)
@@ -155,8 +155,8 @@ class Sem::CLI::Projects < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem projects:secrets:remove renderedtext/cli renderedtext/secrets
-          Secret renderedtext/secrets removed from the project.
+        $ sem projects:secrets:remove renderedtext/cli renderedtext/secrets
+        Secret renderedtext/secrets removed from the project.
     DESC
     def remove(project_name, secret_name)
       project = Sem::API::Project.find!(project_name)

--- a/lib/sem/cli/projects.rb
+++ b/lib/sem/cli/projects.rb
@@ -1,15 +1,15 @@
 class Sem::CLI::Projects < Dracula
 
   desc "list", "list all your projects"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem projects:list
-    NAME
-    ID                                    NAME
-    99c7ed43-ac8a-487e-b488-c38bc757a034  rt/cli
-    99c7ed43-ac8a-487e-b488-c38bc757a034  rt/api
-DESC
+        $ sem projects:list
+        NAME
+        ID                                    NAME
+        99c7ed43-ac8a-487e-b488-c38bc757a034  rt/cli
+        99c7ed43-ac8a-487e-b488-c38bc757a034  rt/api
+  DESC
   def list
     projects = Sem::API::Project.all
 
@@ -21,15 +21,15 @@ DESC
   end
 
   desc "info", "shows detailed information about a project"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem projects:info renderedtext/cli
-    ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name     renderedtext/cli
-    Created  2017-08-01 13:14:40 +0200
-    Updated  2017-08-02 13:14:40 +0200
-DESC
+        $ sem projects:info renderedtext/cli
+        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name     renderedtext/cli
+        Created  2017-08-01 13:14:40 +0200
+        Updated  2017-08-02 13:14:40 +0200
+  DESC
   def info(project_name)
     project = Sem::API::Project.find!(project_name)
 
@@ -38,27 +38,27 @@ DESC
 
   desc "create", "create a project"
   option :url, :aliases => "-u", :desc => "Git url to the repository", :required => true
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem projects:create renderedtext/cli --url git@github.com:renderedtext/cli.git
-    ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name     renderedtext/cli
-    Created  2017-08-01 13:14:40 +0200
-    Updated  2017-08-02 13:14:40 +0200
+        $ sem projects:create renderedtext/cli --url git@github.com:renderedtext/cli.git
+        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name     renderedtext/cli
+        Created  2017-08-01 13:14:40 +0200
+        Updated  2017-08-02 13:14:40 +0200
 
-    $ sem projects:create renderedtext/api --url https://github.com/renderedtext/api
-    ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name     renderedtext/api
-    Created  2017-08-01 13:14:40 +0200
-    Updated  2017-08-02 13:14:40 +0200
+        $ sem projects:create renderedtext/api --url https://github.com/renderedtext/api
+        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name     renderedtext/api
+        Created  2017-08-01 13:14:40 +0200
+        Updated  2017-08-02 13:14:40 +0200
 
-    $ sem projects:create renderedtext/api-tests --url https://github.com/renderedtext/api
-    ID       99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name     renderedtext/api-tests
-    Created  2017-08-01 13:14:40 +0200
-    Updated  2017-08-02 13:14:40 +0200
-DESC
+        $ sem projects:create renderedtext/api-tests --url https://github.com/renderedtext/api
+        ID       99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name     renderedtext/api-tests
+        Created  2017-08-01 13:14:40 +0200
+        Updated  2017-08-02 13:14:40 +0200
+  DESC
   def create(project_name)
     url = Sem::Helpers::GitUrl.new(options[:url])
 
@@ -78,14 +78,14 @@ DESC
   class Files < Dracula
 
     desc "list", "list configuration files for a project"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem projects:files:list renderedtext/cli
-    ID                                    PATH              ENCRYPTED?
-    77c7ed43-ac8a-487e-b488-c38bc757a034  /etc/a            true
-    11c7ed43-bc8a-a87e-ba88-a38ba757a034  /var/secrets.txt  true
-DESC
+          $ sem projects:files:list renderedtext/cli
+          ID                                    PATH              ENCRYPTED?
+          77c7ed43-ac8a-487e-b488-c38bc757a034  /etc/a            true
+          11c7ed43-bc8a-a87e-ba88-a38ba757a034  /var/secrets.txt  true
+    DESC
     def list(project_name)
       project = Sem::API::Project.find!(project_name)
 
@@ -97,14 +97,14 @@ DESC
   class EnvVars < Dracula
 
     desc "list", "list environment variables on project"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem projects:env-vars:list renderedtext/cli
-    ID                                    NAME    ENCRYPTED?  CONTENT
-    9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  false       aaa
-    1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
-DESC
+          $ sem projects:env-vars:list renderedtext/cli
+          ID                                    NAME    ENCRYPTED?  CONTENT
+          9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  false       aaa
+          1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
+    DESC
     def list(project_name)
       project = Sem::API::Project.find!(project_name)
 
@@ -116,14 +116,14 @@ DESC
   class Secrets < Dracula
 
     desc "list", "list secrets on a project"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem projects:secrets:list renderedtext/cli
-    ID                                    NAME                 CONFIG FILES  ENV VARS
-    99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
-    99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/secrets            0         1
-DESC
+          $ sem projects:secrets:list renderedtext/cli
+          ID                                    NAME                 CONFIG FILES  ENV VARS
+          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
+          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/secrets            0         1
+    DESC
     def list(project_name)
       project = Sem::API::Project.find!(project_name)
       secrets = project.secrets
@@ -136,12 +136,12 @@ DESC
     end
 
     desc "add", "attach a secret to a project"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem projects:secrets:add renderedtext/cli renderedtext/secrets
-    Secret renderedtext/secrets added to the project.
-DESC
+          $ sem projects:secrets:add renderedtext/cli renderedtext/secrets
+          Secret renderedtext/secrets added to the project.
+    DESC
     def add(project_name, secret_name)
       project = Sem::API::Project.find!(project_name)
       secret = Sem::API::Secret.find!(secret_name)
@@ -152,12 +152,12 @@ DESC
     end
 
     desc "remove", "removes a secret from the project"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem projects:secrets:remove renderedtext/cli renderedtext/secrets
-    Secret renderedtext/secrets removed from the project.
-DESC
+          $ sem projects:secrets:remove renderedtext/cli renderedtext/secrets
+          Secret renderedtext/secrets removed from the project.
+    DESC
     def remove(project_name, secret_name)
       project = Sem::API::Project.find!(project_name)
       secret = Sem::API::Secret.find!(secret_name)

--- a/lib/sem/cli/secrets.rb
+++ b/lib/sem/cli/secrets.rb
@@ -1,14 +1,14 @@
 class Sem::CLI::Secrets < Dracula
 
   desc "list", "list secrets"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem secrets:list
-    ID                                    NAME                 CONFIG FILES  ENV VARS
-    99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
-    1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
-DESC
+        $ sem secrets:list
+        ID                                    NAME                 CONFIG FILES  ENV VARS
+        99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
+        1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
+  DESC
   def list
     secrets = Sem::API::Secret.all
 
@@ -20,17 +20,17 @@ DESC
   end
 
   desc "info", "show information about secrets"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem secrets:info renderedtext/tokens
-    ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name                   renderedtext/tokens
-    Config Files           1
-    Environment Variables  0
-    Created                2017-08-01 13:14:40 +0200
-    Updated                2017-08-02 13:14:40 +0200
-DESC
+        $ sem secrets:info renderedtext/tokens
+        ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name                   renderedtext/tokens
+        Config Files           1
+        Environment Variables  0
+        Created                2017-08-01 13:14:40 +0200
+        Updated                2017-08-02 13:14:40 +0200
+  DESC
   def info(secret_name)
     secret = Sem::API::Secret.find!(secret_name)
 
@@ -38,17 +38,17 @@ DESC
   end
 
   desc "create", "create new secrets"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem secrets:create renderedtext/tokens
-    ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name                   renderedtext/tokens
-    Config Files           1
-    Environment Variables  0
-    Created                2017-08-01 13:14:40 +0200
-    Updated                2017-08-02 13:14:40 +0200
-DESC
+        $ sem secrets:create renderedtext/tokens
+        ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name                   renderedtext/tokens
+        Config Files           1
+        Environment Variables  0
+        Created                2017-08-01 13:14:40 +0200
+        Updated                2017-08-02 13:14:40 +0200
+  DESC
   def create(secret_name)
     secret = Sem::API::Secret.create!(secret_name)
 
@@ -56,17 +56,17 @@ DESC
   end
 
   desc "rename", "rename secrets"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem secrets:create renderedtext/tokens renderedtext/psst
-    ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
-    Name                   renderedtext/psst
-    Config Files           1
-    Environment Variables  0
-    Created                2017-08-01 13:14:40 +0200
-    Updated                2017-08-02 13:14:40 +0200
-DESC
+        $ sem secrets:create renderedtext/tokens renderedtext/psst
+        ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
+        Name                   renderedtext/psst
+        Config Files           1
+        Environment Variables  0
+        Created                2017-08-01 13:14:40 +0200
+        Updated                2017-08-02 13:14:40 +0200
+  DESC
   def rename(old_secrets_name, new_secrets_name)
     old_org_name, _old_name = Sem::SRN.parse_secret(old_secrets_name)
     new_org_name, new_name = Sem::SRN.parse_secret(new_secrets_name)
@@ -80,12 +80,12 @@ DESC
   end
 
   desc "delete", "removes secrets from your organization"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem secrets:delete renderedtext/tokens
-    Deleted secret renderedtext/tokens.
-DESC
+        $ sem secrets:delete renderedtext/tokens
+        Deleted secret renderedtext/tokens.
+  DESC
   def delete(secrets_name)
     secret = Sem::API::Secret.find!(secrets_name)
     secret.delete!
@@ -96,14 +96,14 @@ DESC
   class Files < Dracula
 
     desc "list", "list files in secrets"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem secrets:files:list renderedtext/tokens
-    ID                                    PATH                      ENCRYPTED?
-    77c7ed43-ac8a-487e-b488-c38bc757a034  /home/runner/a            true
-    11c7ed43-bc8a-a87e-ba88-a38ba757a034  /home/runner/secrets.txt  true
-DESC
+          $ sem secrets:files:list renderedtext/tokens
+          ID                                    PATH                      ENCRYPTED?
+          77c7ed43-ac8a-487e-b488-c38bc757a034  /home/runner/a            true
+          11c7ed43-bc8a-a87e-ba88-a38ba757a034  /home/runner/secrets.txt  true
+    DESC
     def list(secret_name)
       secret = Sem::API::Secret.find!(secret_name)
       files = secret.files
@@ -118,12 +118,12 @@ DESC
     desc "add", "add a file to secrets"
     option "path-on-semaphore", :aliases => "p", :desc => "Path of the file in builds relative to /home/runner directory", :required => true
     option "local-path", :aliases => "l", :desc => "Location of the file on the local machine", :required => true
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem secrets:files:add renderedtext/tokens --local-path /tmp/secrets.json --path-on-semaphore secrets.json
-    Added /home/runner/secrets.txt to renderedtext/secrets.
-DESC
+          $ sem secrets:files:add renderedtext/tokens --local-path /tmp/secrets.json --path-on-semaphore secrets.json
+          Added /home/runner/secrets.txt to renderedtext/secrets.
+    DESC
     def add(secrets_name)
       secret = Sem::API::Secret.find!(secrets_name)
 
@@ -141,12 +141,12 @@ DESC
 
     desc "remove", "remove a file from secrets"
     option :path, :aliases => "p", :desc => "Path of the file in builds relative to /home/runner directory", :required => true
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem secrets:files:remove renderedtext/secrets --path secrets.json
-    Removed /home/runner/secrets.txt from renderedtext/secrets.
-DESC
+          $ sem secrets:files:remove renderedtext/secrets --path secrets.json
+          Removed /home/runner/secrets.txt from renderedtext/secrets.
+    DESC
     def remove(secrets_name)
       secret = Sem::API::Secret.find!(secrets_name)
 
@@ -160,14 +160,14 @@ DESC
   class EnvVars < Dracula
 
     desc "list", "list environment variables in secrets"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem secrets:files:list renderedtext/tokens
-    ID                                    NAME    ENCRYPTED?  CONTENT
-    9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  true        aaa
-    1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
-DESC
+          $ sem secrets:files:list renderedtext/tokens
+          ID                                    NAME    ENCRYPTED?  CONTENT
+          9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  true        aaa
+          1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
+    DESC
     def list(secret_name)
       secret = Sem::API::Secret.find!(secret_name)
       env_vars = secret.env_vars
@@ -182,12 +182,12 @@ DESC
     desc "add", "add an environment variable to secrets"
     option :name, :aliases => "n", :desc => "Name of the variable", :required => true
     option :content, :aliases => "c", :desc => "Content of the variable", :required => true
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem secrets:env-vars:add renderedtext/secrets --name TOKEN --content "s3cr3t"
-    Added TOKEN to renderedtext/secrets.
-DESC
+          $ sem secrets:env-vars:add renderedtext/secrets --name TOKEN --content "s3cr3t"
+          Added TOKEN to renderedtext/secrets.
+    DESC
     def add(secret_name)
       secret = Sem::API::Secret.find!(secret_name)
 
@@ -198,12 +198,12 @@ DESC
 
     desc "remove", "remove an environment variable from secrets"
     option :name, :aliases => "n", :desc => "Name of the variable", :required => true
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem secrets:env-vars:remove renderedtext/secrets --name TOKEN
-    Removed TOKEN from renderedtext/secrets.
-DESC
+          $ sem secrets:env-vars:remove renderedtext/secrets --name TOKEN
+          Removed TOKEN from renderedtext/secrets.
+    DESC
     def remove(secrets_name)
       secret = Sem::API::Secret.find!(secrets_name)
       name = options[:name]

--- a/lib/sem/cli/secrets.rb
+++ b/lib/sem/cli/secrets.rb
@@ -4,10 +4,10 @@ class Sem::CLI::Secrets < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem secrets:list
-        ID                                    NAME                 CONFIG FILES  ENV VARS
-        99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
-        1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
+      $ sem secrets:list
+      ID                                    NAME                 CONFIG FILES  ENV VARS
+      99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
+      1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
   DESC
   def list
     secrets = Sem::API::Secret.all
@@ -23,13 +23,13 @@ class Sem::CLI::Secrets < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem secrets:info renderedtext/tokens
-        ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name                   renderedtext/tokens
-        Config Files           1
-        Environment Variables  0
-        Created                2017-08-01 13:14:40 +0200
-        Updated                2017-08-02 13:14:40 +0200
+      $ sem secrets:info renderedtext/tokens
+      ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name                   renderedtext/tokens
+      Config Files           1
+      Environment Variables  0
+      Created                2017-08-01 13:14:40 +0200
+      Updated                2017-08-02 13:14:40 +0200
   DESC
   def info(secret_name)
     secret = Sem::API::Secret.find!(secret_name)
@@ -41,13 +41,13 @@ class Sem::CLI::Secrets < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem secrets:create renderedtext/tokens
-        ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name                   renderedtext/tokens
-        Config Files           1
-        Environment Variables  0
-        Created                2017-08-01 13:14:40 +0200
-        Updated                2017-08-02 13:14:40 +0200
+      $ sem secrets:create renderedtext/tokens
+      ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name                   renderedtext/tokens
+      Config Files           1
+      Environment Variables  0
+      Created                2017-08-01 13:14:40 +0200
+      Updated                2017-08-02 13:14:40 +0200
   DESC
   def create(secret_name)
     secret = Sem::API::Secret.create!(secret_name)
@@ -59,13 +59,13 @@ class Sem::CLI::Secrets < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem secrets:create renderedtext/tokens renderedtext/psst
-        ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
-        Name                   renderedtext/psst
-        Config Files           1
-        Environment Variables  0
-        Created                2017-08-01 13:14:40 +0200
-        Updated                2017-08-02 13:14:40 +0200
+      $ sem secrets:create renderedtext/tokens renderedtext/psst
+      ID                     99c7ed43-ac8a-487e-b488-c38bc757a034
+      Name                   renderedtext/psst
+      Config Files           1
+      Environment Variables  0
+      Created                2017-08-01 13:14:40 +0200
+      Updated                2017-08-02 13:14:40 +0200
   DESC
   def rename(old_secrets_name, new_secrets_name)
     old_org_name, _old_name = Sem::SRN.parse_secret(old_secrets_name)
@@ -83,8 +83,8 @@ class Sem::CLI::Secrets < Dracula
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem secrets:delete renderedtext/tokens
-        Deleted secret renderedtext/tokens.
+      $ sem secrets:delete renderedtext/tokens
+      Deleted secret renderedtext/tokens.
   DESC
   def delete(secrets_name)
     secret = Sem::API::Secret.find!(secrets_name)
@@ -99,10 +99,10 @@ class Sem::CLI::Secrets < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem secrets:files:list renderedtext/tokens
-          ID                                    PATH                      ENCRYPTED?
-          77c7ed43-ac8a-487e-b488-c38bc757a034  /home/runner/a            true
-          11c7ed43-bc8a-a87e-ba88-a38ba757a034  /home/runner/secrets.txt  true
+        $ sem secrets:files:list renderedtext/tokens
+        ID                                    PATH                      ENCRYPTED?
+        77c7ed43-ac8a-487e-b488-c38bc757a034  /home/runner/a            true
+        11c7ed43-bc8a-a87e-ba88-a38ba757a034  /home/runner/secrets.txt  true
     DESC
     def list(secret_name)
       secret = Sem::API::Secret.find!(secret_name)
@@ -116,13 +116,19 @@ class Sem::CLI::Secrets < Dracula
     end
 
     desc "add", "add a file to secrets"
-    option "path-on-semaphore", :aliases => "p", :desc => "Path of the file in builds relative to /home/runner directory", :required => true
-    option "local-path", :aliases => "l", :desc => "Location of the file on the local machine", :required => true
+    option "path-on-semaphore",
+           :aliases => "p",
+           :desc => "Path of the file in builds relative to /home/runner directory",
+           :required => true
+    option "local-path",
+           :aliases => "l",
+           :desc => "Location of the file on the local machine",
+           :required => true
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem secrets:files:add renderedtext/tokens --local-path /tmp/secrets.json --path-on-semaphore secrets.json
-          Added /home/runner/secrets.txt to renderedtext/secrets.
+        $ sem secrets:files:add rt/tokens --local-path /tmp/secrets.json --path-on-semaphore secrets.json
+        Added /home/runner/secrets.txt to rt/secrets.
     DESC
     def add(secrets_name)
       secret = Sem::API::Secret.find!(secrets_name)
@@ -140,12 +146,15 @@ class Sem::CLI::Secrets < Dracula
     end
 
     desc "remove", "remove a file from secrets"
-    option :path, :aliases => "p", :desc => "Path of the file in builds relative to /home/runner directory", :required => true
+    option :path,
+           :aliases => "p",
+           :desc => "Path of the file in builds relative to /home/runner directory",
+           :required => true
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem secrets:files:remove renderedtext/secrets --path secrets.json
-          Removed /home/runner/secrets.txt from renderedtext/secrets.
+        $ sem secrets:files:remove renderedtext/secrets --path secrets.json
+        Removed /home/runner/secrets.txt from renderedtext/secrets.
     DESC
     def remove(secrets_name)
       secret = Sem::API::Secret.find!(secrets_name)
@@ -163,10 +172,10 @@ class Sem::CLI::Secrets < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem secrets:files:list renderedtext/tokens
-          ID                                    NAME    ENCRYPTED?  CONTENT
-          9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  true        aaa
-          1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
+        $ sem secrets:files:list renderedtext/tokens
+        ID                                    NAME    ENCRYPTED?  CONTENT
+        9997ed43-ac8a-487e-b488-c38bc757a034  SECRET  true        aaa
+        1117ed43-tc8a-387e-6488-838bc757a034  TOKEN   true        *encrypted*
     DESC
     def list(secret_name)
       secret = Sem::API::Secret.find!(secret_name)
@@ -185,8 +194,8 @@ class Sem::CLI::Secrets < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem secrets:env-vars:add renderedtext/secrets --name TOKEN --content "s3cr3t"
-          Added TOKEN to renderedtext/secrets.
+        $ sem secrets:env-vars:add renderedtext/secrets --name TOKEN --content "s3cr3t"
+        Added TOKEN to renderedtext/secrets.
     DESC
     def add(secret_name)
       secret = Sem::API::Secret.find!(secret_name)
@@ -201,8 +210,8 @@ class Sem::CLI::Secrets < Dracula
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem secrets:env-vars:remove renderedtext/secrets --name TOKEN
-          Removed TOKEN from renderedtext/secrets.
+        $ sem secrets:env-vars:remove renderedtext/secrets --name TOKEN
+        Removed TOKEN from renderedtext/secrets.
     DESC
     def remove(secrets_name)
       secret = Sem::API::Secret.find!(secrets_name)

--- a/lib/sem/cli/teams.rb
+++ b/lib/sem/cli/teams.rb
@@ -6,10 +6,10 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem teams:list
-        ID                                    NAME                 PERMISSION  MEMBERS
-        1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/devs    write       2 members
-        1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/admins  write       0 members
+      $ sem teams:list
+      ID                                    NAME                 PERMISSION  MEMBERS
+      1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/devs    write       2 members
+      1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/admins  write       0 members
   DESC
   def list
     teams = Sem::API::Team.all
@@ -25,13 +25,13 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem teams:info renderedtext/admins
-        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-        Name        renderedtext/admins
-        Permission  edit
-        Members     2 members
-        Created     2017-08-01 13:14:40 +0200
-        Updated     2017-08-02 13:14:40 +0200
+      $ sem teams:info renderedtext/admins
+      ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name        renderedtext/admins
+      Permission  edit
+      Members     2 members
+      Created     2017-08-01 13:14:40 +0200
+      Updated     2017-08-02 13:14:40 +0200
   DESC
   def info(team_name)
     team = Sem::API::Team.find!(team_name)
@@ -46,29 +46,29 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem teams:create renderedtext/interns
-        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-        Name        renderedtext/interns
-        Permission  read
-        Members     0 members
-        Created     2017-08-01 13:14:40 +0200
-        Updated     2017-08-02 13:14:40 +0200
+      $ sem teams:create renderedtext/interns
+      ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name        renderedtext/interns
+      Permission  read
+      Members     0 members
+      Created     2017-08-01 13:14:40 +0200
+      Updated     2017-08-02 13:14:40 +0200
 
-        $ sem teams:create renderedtext/devs --permission edit
-        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-        Name        renderedtext/devs
-        Permission  edit
-        Members     0 members
-        Created     2017-08-01 13:14:40 +0200
-        Updated     2017-08-02 13:14:40 +0200
+      $ sem teams:create renderedtext/devs --permission edit
+      ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name        renderedtext/devs
+      Permission  edit
+      Members     0 members
+      Created     2017-08-01 13:14:40 +0200
+      Updated     2017-08-02 13:14:40 +0200
 
-        $ sem teams:create renderedtext/admins --permission admin
-        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-        Name        renderedtext/admins
-        Permission  admin
-        Members     0 members
-        Created     2017-08-01 13:14:40 +0200
-        Updated     2017-08-02 13:14:40 +0200
+      $ sem teams:create renderedtext/admins --permission admin
+      ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name        renderedtext/admins
+      Permission  admin
+      Members     0 members
+      Created     2017-08-01 13:14:40 +0200
+      Updated     2017-08-02 13:14:40 +0200
   DESC
   def create(team_name)
     permission = options[:permission]
@@ -86,13 +86,13 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem teams:create renderedtext/interns renderedtext/juniors
-        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-        Name        renderedtext/juniors
-        Permission  read
-        Members     0 members
-        Created     2017-08-01 13:14:40 +0200
-        Updated     2017-08-02 13:14:40 +0200
+      $ sem teams:create renderedtext/interns renderedtext/juniors
+      ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name        renderedtext/juniors
+      Permission  read
+      Members     0 members
+      Created     2017-08-01 13:14:40 +0200
+      Updated     2017-08-02 13:14:40 +0200
   DESC
   def rename(old_team_name, new_team_name)
     old_org_name, _old_name = Sem::SRN.parse_team(old_team_name)
@@ -114,13 +114,13 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem teams:set-permission renderedtext/interns --permission edit
-        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-        Name        renderedtext/interns
-        Permission  edit
-        Members     0 members
-        Created     2017-08-01 13:14:40 +0200
-        Updated     2017-08-02 13:14:40 +0200
+      $ sem teams:set-permission renderedtext/interns --permission edit
+      ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+      Name        renderedtext/interns
+      Permission  edit
+      Members     0 members
+      Created     2017-08-01 13:14:40 +0200
+      Updated     2017-08-02 13:14:40 +0200
   DESC
   def set_permission(team_name) # rubocop:disable Style/AccessorMethodName
     permission = options[:permission]
@@ -139,8 +139,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   long_desc <<-DESC.strip_heredoc
     Examples:
 
-        $ sem teams:delete renderedtext/interns
-        Team renderedtext/interns deleted.
+      $ sem teams:delete renderedtext/interns
+      Team renderedtext/interns deleted.
   DESC
   def delete(team_name)
     team = Sem::API::Team.find!(team_name)
@@ -154,11 +154,11 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem teams:members:list renderedtext/interns
-          NAME
-          shiroyasha
-          darko
-          ervinb
+        $ sem teams:members:list renderedtext/interns
+        NAME
+        shiroyasha
+        darko
+        ervinb
     DESC
     def list(team_name)
       team = Sem::API::Team.find!(team_name)
@@ -175,8 +175,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem teams:members:add renderedtext/interns shiroyasha
-          User shiroyasha added to the team.
+        $ sem teams:members:add renderedtext/interns shiroyasha
+        User shiroyasha added to the team.
     DESC
     def add(team_name, username)
       team = Sem::API::Team.find!(team_name)
@@ -189,8 +189,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem teams:members:remove renderedtext/interns shiroyasha
-          User shiroyasha removed from the team.
+        $ sem teams:members:remove renderedtext/interns shiroyasha
+        User shiroyasha removed from the team.
     DESC
     def remove(team_name, username)
       team = Sem::API::Team.find!(team_name)
@@ -205,11 +205,11 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem team:projects:list renderedtext/devs
-          NAME
-          ID                                    NAME
-          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/cli
-          12c7ed43-4444-487e-b488-c38bc757a034  renderedtext/api
+        $ sem team:projects:list renderedtext/devs
+        NAME
+        ID                                    NAME
+        99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/cli
+        12c7ed43-4444-487e-b488-c38bc757a034  renderedtext/api
     DESC
     def list(team_name)
       team = Sem::API::Team.find!(team_name)
@@ -226,8 +226,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem team:projects:add renderedtext/devs renderedtext/cli
-          Project renderedtext/cli added to the team.
+        $ sem team:projects:add renderedtext/devs renderedtext/cli
+        Project renderedtext/cli added to the team.
     DESC
     def add(team_name, project_name)
       team = Sem::API::Team.find!(team_name)
@@ -242,8 +242,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem team:projects:remove renderedtext/devs renderedtext/cli
-          Project renderedtext/cli removed from the team.
+        $ sem team:projects:remove renderedtext/devs renderedtext/cli
+        Project renderedtext/cli removed from the team.
     DESC
     def remove(team_name, project_name)
       team = Sem::API::Team.find!(team_name)
@@ -260,10 +260,10 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem team:secrets:list renderedtext/devs
-          ID                                    NAME                 CONFIG FILES  ENV VARS
-          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
-          1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
+        $ sem team:secrets:list renderedtext/devs
+        ID                                    NAME                 CONFIG FILES  ENV VARS
+        99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
+        1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
     DESC
     def list(team_name)
       team = Sem::API::Team.find!(team_name)
@@ -280,8 +280,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem team:secrets:add renderedtext/devs renderedtext/tokens
-          Secrets renderedtext/token added to the team.
+        $ sem team:secrets:add renderedtext/devs renderedtext/tokens
+        Secrets renderedtext/token added to the team.
     DESC
     def add(team_name, secret_name)
       team = Sem::API::Team.find!(team_name)
@@ -296,8 +296,8 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
     long_desc <<-DESC.strip_heredoc
       Examples:
 
-          $ sem team:secrets:remove renderedtext/devs renderedtext/secrets
-          Secrets renderedtext/secrets removed from the team.
+        $ sem team:secrets:remove renderedtext/devs renderedtext/secrets
+        Secrets renderedtext/secrets removed from the team.
     DESC
     def remove(team_name, secret_name)
       team = Sem::API::Team.find!(team_name)

--- a/lib/sem/cli/teams.rb
+++ b/lib/sem/cli/teams.rb
@@ -3,14 +3,14 @@ class Sem::CLI::Teams < Dracula # rubocop:disable Metrics/ClassLength
   ALLOWED_PERMISSIONS = ["admin", "edit", "read"].freeze
 
   desc "list", "list all your teams"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem teams:list
-    ID                                    NAME                 PERMISSION  MEMBERS
-    1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/devs    write       2 members
-    1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/admins  write       0 members
-DESC
+        $ sem teams:list
+        ID                                    NAME                 PERMISSION  MEMBERS
+        1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/devs    write       2 members
+        1bc7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/admins  write       0 members
+  DESC
   def list
     teams = Sem::API::Team.all
 
@@ -22,17 +22,17 @@ DESC
   end
 
   desc "info", "show information about a team"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem teams:info renderedtext/admins
-    ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name        renderedtext/admins
-    Permission  edit
-    Members     2 members
-    Created     2017-08-01 13:14:40 +0200
-    Updated     2017-08-02 13:14:40 +0200
-DESC
+        $ sem teams:info renderedtext/admins
+        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+        Name        renderedtext/admins
+        Permission  edit
+        Members     2 members
+        Created     2017-08-01 13:14:40 +0200
+        Updated     2017-08-02 13:14:40 +0200
+  DESC
   def info(team_name)
     team = Sem::API::Team.find!(team_name)
 
@@ -43,33 +43,33 @@ DESC
   option :permission, :default => "read",
                       :aliases => "p",
                       :desc => "Permission level of the team in the organization"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem teams:create renderedtext/interns
-    ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name        renderedtext/interns
-    Permission  read
-    Members     0 members
-    Created     2017-08-01 13:14:40 +0200
-    Updated     2017-08-02 13:14:40 +0200
+        $ sem teams:create renderedtext/interns
+        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+        Name        renderedtext/interns
+        Permission  read
+        Members     0 members
+        Created     2017-08-01 13:14:40 +0200
+        Updated     2017-08-02 13:14:40 +0200
 
-    $ sem teams:create renderedtext/devs --permission edit
-    ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name        renderedtext/devs
-    Permission  edit
-    Members     0 members
-    Created     2017-08-01 13:14:40 +0200
-    Updated     2017-08-02 13:14:40 +0200
+        $ sem teams:create renderedtext/devs --permission edit
+        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+        Name        renderedtext/devs
+        Permission  edit
+        Members     0 members
+        Created     2017-08-01 13:14:40 +0200
+        Updated     2017-08-02 13:14:40 +0200
 
-    $ sem teams:create renderedtext/admins --permission admin
-    ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name        renderedtext/admins
-    Permission  admin
-    Members     0 members
-    Created     2017-08-01 13:14:40 +0200
-    Updated     2017-08-02 13:14:40 +0200
-DESC
+        $ sem teams:create renderedtext/admins --permission admin
+        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+        Name        renderedtext/admins
+        Permission  admin
+        Members     0 members
+        Created     2017-08-01 13:14:40 +0200
+        Updated     2017-08-02 13:14:40 +0200
+  DESC
   def create(team_name)
     permission = options[:permission]
 
@@ -83,17 +83,17 @@ DESC
   end
 
   desc "rename", "change the name of the team"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem teams:create renderedtext/interns renderedtext/juniors
-    ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name        renderedtext/juniors
-    Permission  read
-    Members     0 members
-    Created     2017-08-01 13:14:40 +0200
-    Updated     2017-08-02 13:14:40 +0200
-DESC
+        $ sem teams:create renderedtext/interns renderedtext/juniors
+        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+        Name        renderedtext/juniors
+        Permission  read
+        Members     0 members
+        Created     2017-08-01 13:14:40 +0200
+        Updated     2017-08-02 13:14:40 +0200
+  DESC
   def rename(old_team_name, new_team_name)
     old_org_name, _old_name = Sem::SRN.parse_team(old_team_name)
     new_org_name, new_name = Sem::SRN.parse_team(new_team_name)
@@ -111,17 +111,17 @@ DESC
                       :required => true,
                       :aliases => "p",
                       :desc => "Permission level of the team in the organization"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem teams:set-permission renderedtext/interns --permission edit
-    ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
-    Name        renderedtext/interns
-    Permission  edit
-    Members     0 members
-    Created     2017-08-01 13:14:40 +0200
-    Updated     2017-08-02 13:14:40 +0200
-DESC
+        $ sem teams:set-permission renderedtext/interns --permission edit
+        ID          1bc7ed43-ac8a-487e-b488-c38bc757a034
+        Name        renderedtext/interns
+        Permission  edit
+        Members     0 members
+        Created     2017-08-01 13:14:40 +0200
+        Updated     2017-08-02 13:14:40 +0200
+  DESC
   def set_permission(team_name) # rubocop:disable Style/AccessorMethodName
     permission = options[:permission]
 
@@ -136,12 +136,12 @@ DESC
   end
 
   desc "delete", "removes a team from your organization"
-  long_desc <<-DESC
-Examples:
+  long_desc <<-DESC.strip_heredoc
+    Examples:
 
-    $ sem teams:delete renderedtext/interns
-    Team renderedtext/interns deleted.
-DESC
+        $ sem teams:delete renderedtext/interns
+        Team renderedtext/interns deleted.
+  DESC
   def delete(team_name)
     team = Sem::API::Team.find!(team_name)
     team.delete!
@@ -151,15 +151,15 @@ DESC
 
   class Members < Dracula
     desc "list", "list members of the team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem teams:members:list renderedtext/interns
-    NAME
-    shiroyasha
-    darko
-    ervinb
-DESC
+          $ sem teams:members:list renderedtext/interns
+          NAME
+          shiroyasha
+          darko
+          ervinb
+    DESC
     def list(team_name)
       team = Sem::API::Team.find!(team_name)
       users = team.users
@@ -172,12 +172,12 @@ DESC
     end
 
     desc "add", "add a user to the team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem teams:members:add renderedtext/interns shiroyasha
-    User shiroyasha added to the team.
-DESC
+          $ sem teams:members:add renderedtext/interns shiroyasha
+          User shiroyasha added to the team.
+    DESC
     def add(team_name, username)
       team = Sem::API::Team.find!(team_name)
       team.add_user(username)
@@ -186,12 +186,12 @@ DESC
     end
 
     desc "remove", "remove a user from the team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem teams:members:remove renderedtext/interns shiroyasha
-    User shiroyasha removed from the team.
-DESC
+          $ sem teams:members:remove renderedtext/interns shiroyasha
+          User shiroyasha removed from the team.
+    DESC
     def remove(team_name, username)
       team = Sem::API::Team.find!(team_name)
       team.remove_user(username)
@@ -202,15 +202,15 @@ DESC
 
   class Projects < Dracula
     desc "list", "list projects in a team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem team:projects:list renderedtext/devs
-    NAME
-    ID                                    NAME
-    99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/cli
-    12c7ed43-4444-487e-b488-c38bc757a034  renderedtext/api
-DESC
+          $ sem team:projects:list renderedtext/devs
+          NAME
+          ID                                    NAME
+          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/cli
+          12c7ed43-4444-487e-b488-c38bc757a034  renderedtext/api
+    DESC
     def list(team_name)
       team = Sem::API::Team.find!(team_name)
       projects = team.projects
@@ -223,12 +223,12 @@ DESC
     end
 
     desc "add", "add a project to a team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem team:projects:add renderedtext/devs renderedtext/cli
-    Project renderedtext/cli added to the team.
-DESC
+          $ sem team:projects:add renderedtext/devs renderedtext/cli
+          Project renderedtext/cli added to the team.
+    DESC
     def add(team_name, project_name)
       team = Sem::API::Team.find!(team_name)
       project = Sem::API::Project.find!(project_name)
@@ -239,12 +239,12 @@ DESC
     end
 
     desc "remove", "remove a project from the team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem team:projects:remove renderedtext/devs renderedtext/cli
-    Project renderedtext/cli removed from the team.
-DESC
+          $ sem team:projects:remove renderedtext/devs renderedtext/cli
+          Project renderedtext/cli removed from the team.
+    DESC
     def remove(team_name, project_name)
       team = Sem::API::Team.find!(team_name)
       project = Sem::API::Project.find!(project_name)
@@ -257,14 +257,14 @@ DESC
 
   class Secrets < Dracula
     desc "list", "list secrets in a team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem team:secrets:list renderedtext/devs
-    ID                                    NAME                 CONFIG FILES  ENV VARS
-    99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
-    1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
-DESC
+          $ sem team:secrets:list renderedtext/devs
+          ID                                    NAME                 CONFIG FILES  ENV VARS
+          99c7ed43-ac8a-487e-b488-c38bc757a034  renderedtext/tokens             1         0
+          1133ed43-ac8a-487e-b488-c38bc757a044  renderedtext/secrets            0         1
+    DESC
     def list(team_name)
       team = Sem::API::Team.find!(team_name)
       configs = team.secrets
@@ -277,12 +277,12 @@ DESC
     end
 
     desc "add", "add secrets to a team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem team:secrets:add renderedtext/devs renderedtext/tokens
-    Secrets renderedtext/token added to the team.
-DESC
+          $ sem team:secrets:add renderedtext/devs renderedtext/tokens
+          Secrets renderedtext/token added to the team.
+    DESC
     def add(team_name, secret_name)
       team = Sem::API::Team.find!(team_name)
       secret = Sem::API::Secret.find!(secret_name)
@@ -293,12 +293,12 @@ DESC
     end
 
     desc "remove", "removes secrets from the team"
-    long_desc <<-DESC
-Examples:
+    long_desc <<-DESC.strip_heredoc
+      Examples:
 
-    $ sem team:secrets:remove renderedtext/devs renderedtext/secrets
-    Secrets renderedtext/secrets removed from the team.
-DESC
+          $ sem team:secrets:remove renderedtext/devs renderedtext/secrets
+          Secrets renderedtext/secrets removed from the team.
+    DESC
     def remove(team_name, secret_name)
       team = Sem::API::Team.find!(team_name)
       secret = Sem::API::Secret.find!(secret_name)

--- a/lib/sem/core_ext/string.rb
+++ b/lib/sem/core_ext/string.rb
@@ -1,0 +1,35 @@
+class String
+  # This was copied from:
+  # activesupport/lib/active_support/core_ext/string/strip.rb
+  #
+  # Instead of importing the whole activesupport library,
+  # we are only importing this one method.
+  #
+  # Is this safe?
+  # The assumption is that the CLI will not be included in other
+  # projects as a gem. That mitigates possible side effects.
+  #
+  # ---------------------------------------------------------------------------
+  #
+  # Strips indentation in heredocs.
+  #
+  # For example in
+  #
+  #   if options[:usage]
+  #     puts <<-USAGE.strip_heredoc
+  #       This command does such and such.
+  #
+  #       Supported options are:
+  #         -h         This message
+  #         ...
+  #     USAGE
+  #   end
+  #
+  # the user would see the usage message aligned against the left margin.
+  #
+  # Technically, it looks for the least indented non-empty line
+  # in the whole string, and removes that amount of leading whitespace.
+  def strip_heredoc
+    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, "".freeze)
+  end
+end


### PR DESCRIPTION
This makes the controller classes in the `sem/cli/*.rb` namespace cleaner.

Usually, we would use the squiggly heredocs syntax `<~HERE`, but it is
only available in Ruby >= 2.3. The CLI needs to support Ruby >= 2.0.

The `strip_heredoc` was imported from ActiveSupport as a core_ext for the String class.